### PR TITLE
Avoid boxing allocation issues

### DIFF
--- a/src/systems.cs
+++ b/src/systems.cs
@@ -96,7 +96,7 @@ namespace Leopotam.EcsLite.Threads {
                 _pool1.GetRawDenseItems (), _pool1.GetRawSparseItems (),
                 _pool2.GetRawDenseItems (), _pool2.GetRawSparseItems (),
                 _pool3.GetRawDenseItems (), _pool3.GetRawSparseItems ());
-            SetData (systems, _thread);
+            SetData (systems, ref _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
@@ -104,7 +104,7 @@ namespace Leopotam.EcsLite.Threads {
             _thread.Execute (fromIndex, beforeIndex);
         }
 
-        protected virtual void SetData (EcsSystems systems, TThread thread) { }
+        protected virtual void SetData (EcsSystems systems, ref TThread thread) { }
     }
 
     public abstract class EcsThreadSystem<TThread, T1, T2, T3, T4> : EcsThreadSystemBase, IEcsRunSystem

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -28,8 +28,7 @@ namespace Leopotam.EcsLite.Threads {
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
-        private void Execute (int fromIndex, int beforeIndex)
-        {
+        private void Execute (int fromIndex, int beforeIndex) {
             _thread.Execute (fromIndex, beforeIndex);
         }
 

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -24,7 +24,7 @@ namespace Leopotam.EcsLite.Threads {
             _thread.Init (
                 _filter.GetRawEntities (),
                 _pool1.GetRawDenseItems (), _pool1.GetRawSparseItems ());
-            SetData (systems, _thread);
+            SetData (systems, ref _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
@@ -32,7 +32,7 @@ namespace Leopotam.EcsLite.Threads {
             _thread.Execute (fromIndex, beforeIndex);
         }
 
-        protected virtual void SetData (EcsSystems systems, TThread thread) { }
+        protected virtual void SetData (EcsSystems systems, ref TThread thread) { }
     }
 
     public abstract class EcsThreadSystem<TThread, T1, T2> : EcsThreadSystemBase, IEcsRunSystem
@@ -58,7 +58,7 @@ namespace Leopotam.EcsLite.Threads {
                 _filter.GetRawEntities (),
                 _pool1.GetRawDenseItems (), _pool1.GetRawSparseItems (),
                 _pool2.GetRawDenseItems (), _pool2.GetRawSparseItems ());
-            SetData (systems, _thread);
+            SetData (systems, ref _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
@@ -66,7 +66,7 @@ namespace Leopotam.EcsLite.Threads {
             _thread.Execute (fromIndex, beforeIndex);
         }
 
-        protected virtual void SetData (EcsSystems systems, TThread thread) { }
+        protected virtual void SetData (EcsSystems systems, ref TThread thread) { }
     }
 
     public abstract class EcsThreadSystem<TThread, T1, T2, T3> : EcsThreadSystemBase, IEcsRunSystem
@@ -138,7 +138,7 @@ namespace Leopotam.EcsLite.Threads {
                 _pool2.GetRawDenseItems (), _pool2.GetRawSparseItems (),
                 _pool3.GetRawDenseItems (), _pool3.GetRawSparseItems (),
                 _pool4.GetRawDenseItems (), _pool4.GetRawSparseItems ());
-            SetData (systems, _thread);
+            SetData (systems, ref _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
@@ -146,7 +146,7 @@ namespace Leopotam.EcsLite.Threads {
             _thread.Execute (fromIndex, beforeIndex);
         }
 
-        protected virtual void SetData (EcsSystems systems, TThread thread) { }
+        protected virtual void SetData (EcsSystems systems, ref TThread thread) { }
     }
 
     public abstract class EcsThreadSystemBase {

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -6,7 +6,7 @@
 
 namespace Leopotam.EcsLite.Threads {
     public abstract class EcsThreadSystem<TThread, T1> : EcsThreadSystemBase, IEcsRunSystem
-        where TThread : class, IEcsThread<T1>, new ()
+        where TThread : struct, IEcsThread<T1>
         where T1 : struct {
         EcsFilter _filter;
         EcsPool<T1> _pool1;
@@ -19,13 +19,18 @@ namespace Leopotam.EcsLite.Threads {
                 _pool1 = world.GetPool<T1> ();
                 _filter = GetFilter (world);
                 _thread = new TThread ();
-                _worker = _thread.Execute;
+                _worker = Execute;
             }
             _thread.Init (
                 _filter.GetRawEntities (),
                 _pool1.GetRawDenseItems (), _pool1.GetRawSparseItems ());
             SetData (systems, _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
+        }
+
+        private void Execute (int fromIndex, int beforeIndex)
+        {
+            _thread.Execute(fromIndex, beforeIndex);
         }
 
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
@@ -40,7 +45,7 @@ namespace Leopotam.EcsLite.Threads {
         EcsPool<T2> _pool2;
         TThread _thread;
         ThreadWorkerHandler _worker;
-    
+
         public void Run (EcsSystems systems) {
             if (_filter == null) {
                 var world = GetWorld (systems);
@@ -48,7 +53,7 @@ namespace Leopotam.EcsLite.Threads {
                 _pool2 = world.GetPool<T2> ();
                 _filter = GetFilter (world);
                 _thread = new TThread ();
-                _worker = _thread.Execute;
+                _worker = Execute;
             }
             _thread.Init (
                 _filter.GetRawEntities (),
@@ -57,10 +62,15 @@ namespace Leopotam.EcsLite.Threads {
             SetData (systems, _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
-    
+
+        private void Execute (int fromIndex, int beforeIndex)
+        {
+            _thread.Execute(fromIndex, beforeIndex);
+        }
+
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
     }
-    
+
     public abstract class EcsThreadSystem<TThread, T1, T2, T3> : EcsThreadSystemBase, IEcsRunSystem
         where TThread : struct, IEcsThread<T1, T2, T3>
         where T1 : struct
@@ -81,7 +91,7 @@ namespace Leopotam.EcsLite.Threads {
                 _pool3 = world.GetPool<T3> ();
                 _filter = GetFilter (world);
                 _thread = new TThread ();
-                _worker = _thread.Execute;
+                _worker = Execute;
             }
             _thread.Init (
                 _filter.GetRawEntities (),
@@ -91,10 +101,15 @@ namespace Leopotam.EcsLite.Threads {
             SetData (systems, _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
-    
+
+        private void Execute (int fromIndex, int beforeIndex)
+        {
+            _thread.Execute(fromIndex, beforeIndex);
+        }
+
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
     }
-    
+
     public abstract class EcsThreadSystem<TThread, T1, T2, T3, T4> : EcsThreadSystemBase, IEcsRunSystem
         where TThread : struct, IEcsThread<T1, T2, T3, T4>
         where T1 : struct
@@ -118,7 +133,7 @@ namespace Leopotam.EcsLite.Threads {
                 _pool4 = world.GetPool<T4> ();
                 _filter = GetFilter (world);
                 _thread = new TThread ();
-                _worker = _thread.Execute;
+                _worker = Execute;
             }
             _thread.Init (
                 _filter.GetRawEntities (),
@@ -129,7 +144,12 @@ namespace Leopotam.EcsLite.Threads {
             SetData (systems, _thread);
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
-    
+
+        private void Execute (int fromIndex, int beforeIndex)
+        {
+            _thread.Execute(fromIndex, beforeIndex);
+        }
+
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
     }
 

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -30,7 +30,7 @@ namespace Leopotam.EcsLite.Threads {
 
         private void Execute (int fromIndex, int beforeIndex)
         {
-            _thread.Execute(fromIndex, beforeIndex);
+            _thread.Execute (fromIndex, beforeIndex);
         }
 
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
@@ -64,7 +64,7 @@ namespace Leopotam.EcsLite.Threads {
         }
 
         void Execute (int fromIndex, int beforeIndex) {
-            _thread.Execute(fromIndex, beforeIndex);
+            _thread.Execute (fromIndex, beforeIndex);
         }
 
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
@@ -102,7 +102,7 @@ namespace Leopotam.EcsLite.Threads {
         }
 
         void Execute (int fromIndex, int beforeIndex) {
-            _thread.Execute(fromIndex, beforeIndex);
+            _thread.Execute (fromIndex, beforeIndex);
         }
 
         protected virtual void SetData (EcsSystems systems, TThread thread) { }
@@ -144,7 +144,7 @@ namespace Leopotam.EcsLite.Threads {
         }
 
         void Execute (int fromIndex, int beforeIndex) {
-            _thread.Execute(fromIndex, beforeIndex);
+            _thread.Execute (fromIndex, beforeIndex);
         }
 
         protected virtual void SetData (EcsSystems systems, TThread thread) { }

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -63,8 +63,7 @@ namespace Leopotam.EcsLite.Threads {
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
-        private void Execute (int fromIndex, int beforeIndex)
-        {
+        void Execute (int fromIndex, int beforeIndex) {
             _thread.Execute(fromIndex, beforeIndex);
         }
 
@@ -102,8 +101,7 @@ namespace Leopotam.EcsLite.Threads {
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
-        private void Execute (int fromIndex, int beforeIndex)
-        {
+        void Execute (int fromIndex, int beforeIndex) {
             _thread.Execute(fromIndex, beforeIndex);
         }
 
@@ -145,8 +143,7 @@ namespace Leopotam.EcsLite.Threads {
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
-        private void Execute (int fromIndex, int beforeIndex)
-        {
+        void Execute (int fromIndex, int beforeIndex) {
             _thread.Execute(fromIndex, beforeIndex);
         }
 

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -28,7 +28,7 @@ namespace Leopotam.EcsLite.Threads {
             ThreadService.Run (_worker, _filter.GetEntitiesCount (), GetChunkSize (systems));
         }
 
-        private void Execute (int fromIndex, int beforeIndex) {
+        void Execute (int fromIndex, int beforeIndex) {
             _thread.Execute (fromIndex, beforeIndex);
         }
 


### PR DESCRIPTION
Hi. If i understand correct. abstract class with two and three component has problem with boxing allocation. 
Because, those classes use TThread as struct and when we call:
_worker = _thread.Execute <-- boxing allocation and copy of this struct move to heap.
Then we call init on local struct but _worker refer to another copy(after boxing) of this struct without data.